### PR TITLE
Don't register_asset handlebar template

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -15,9 +15,6 @@ register_svg_icon "history" if respond_to?(:register_svg_icon)
 # Register admin settings
 enabled_site_setting :discpage_enabled
 
-# Register the template to restore the create topic button
-register_asset "javascripts/discourse/templates/components/create-topic-button.hbs"
-
 # In Discourse, editing the *last* post of a topic bumps the topic. A DiscPage
 # static page is almost always the only post of a topic (because further posts
 # are never displayed). It means any minor edit in the static page will bump it.


### PR DESCRIPTION
Upon installing the new discourse version, I got this error: "[discpage] Handlebars templates can no longer be included via `register_asset`.". To fix it, I've removed register_asset from plugin.rb, because according to discourse, ["Any hbs files under `assets/javascripts` will be automatically compiled and included."](https://github.com/discourse/discourse/blob/337a033f3b37c4bfc47bafb4247ef118e11fa293/lib/plugin/instance.rb#L592).
Discourse works for me with no issue.